### PR TITLE
[FEATURE] Add Init script for first run of GDI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,16 @@
 
 ## Overview
 
-**GDI** (Grove Developer Interface) is a CLI for
-useful internal tooling for Grove's developer tools and resources.
+The 🌿 Grove Developer Interface (GDI) 🌿 is a command-line tool designed to streamline
+internal developer workflows at Grove. GDI is intended to help developers quickly perform
+routine operations and maintain consistency across projects.
+
+**DEV_NOTE:**
+
+This repo is also intended to be a living project and should be updated to incorporate
+any of our own scripts, hacks, time-saving features, etc. that we use in our local
+development workflows and that could benefit the entire team to share in this CLI
+
 
 It is created using the [CobraCLI library](https://github.com/spf13/cobra).
 
@@ -17,6 +25,8 @@ It is created using the [CobraCLI library](https://github.com/spf13/cobra).
 The configuration is done through a config YAML file located at `~/.config.gdi.yaml`.
 
 An example configuration file can be found at `config/examples/.config.example.yaml`.
+
+Configuration can be updated using the interactive command `gdi config`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -5,19 +5,52 @@
 </div>
 <br/>
 
+## Table of Contents <!-- omit in toc -->
+
+- [Overview](#overview)
+- [Usage](#usage)
+  - [gdi](#gdi)
+  - [gdi git createpr](#gdi-git-createpr)
+  - [gdi config](#gdi-config)
+- [Configuration](#configuration)
+
+
 ## Overview
 
 The 🌿 Grove Developer Interface (GDI) 🌿 is a command-line tool designed to streamline
 internal developer workflows at Grove. GDI is intended to help developers quickly perform
 routine operations and maintain consistency across projects.
 
-_**DEV_NOTE:**_
+## Usage
 
-_This repo is also intended to be a living project and should be updated to incorporate
-any of our own scripts, hacks, time-saving features, etc. that we use in our local
-development workflows and that could benefit the entire team to share in this CLI_
+The Grove Developer Interface (GDI) enables streamlined internal development workflows by providing a unified command-line interface **to** manage configuration settings, execute Git operations, and more. Below are tables of available commands and their flags:
 
-It is created using the [CobraCLI library](https://github.com/spf13/cobra).
+### gdi
+
+| Flag         | Type | Required | Description                          |
+| ------------ | ---- | -------- | ------------------------------------ |
+| -t, --toggle | bool | ❌        | Toggle verbose mode or other options |
+| -h, --help   | bool | ❌        | Show help for gdi                    |
+
+### gdi git createpr
+
+| Flag                     | Type   | Required | Description                                                                         |
+| ------------------------ | ------ | -------- | ----------------------------------------------------------------------------------- |
+| --pr-title (-t)          | string | ✅        | PR title. Will open a draft PR if the string contains [DRAFT] or [WIP]              |
+| --target-branch (-b)     | string | ❌        | Target branch (default "main")                                                      |
+| --issue (-i)             | int    | ❌        | Issue number                                                                        |
+| --dummy (-d)             | bool   | ❌        | Dummy mode. Will print summary to console and clipboard but not open a PR on GitHub |
+| --provider-override (-p) | string | ❌        | LLM provider override. Sets the LLM provider only for this request                  |
+| --model-override (-m)    | string | ❌        | LLM model override. Sets the LLM model only for this request                        |
+
+### gdi config
+
+| Flag          | Type   | Required | Description                                                                  |
+| ------------- | ------ | -------- | ---------------------------------------------------------------------------- |
+| --show (-s)   | bool   | ❌        | Show the configuration                                                       |
+| --editor (-e) | string | ❌        | Edit the configuration in the given text editor, for example `nano` or `vim` |
+
+To run the interactive editor, run without any flags, ie. `gdi config`.
 
 ## Configuration
 
@@ -27,8 +60,3 @@ An example configuration file can be found at `config/examples/.config.example.y
 
 Configuration can be updated using the interactive command `gdi config`.
 
-## Usage
-
-```bash
-gdi --help
-```

--- a/cmd/config/init.go
+++ b/cmd/config/init.go
@@ -1,0 +1,196 @@
+package config
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"golang.org/x/term"
+	"gopkg.in/yaml.v3"
+
+	configPkg "github.com/buildwithgrove/gdi/config"
+)
+
+// ConfigExists checks if the configuration file exists.
+// It is used to determine if we should run the first-time setup.
+func ConfigExists() bool {
+	_, err := os.Stat(configPkg.ConfigFilePath)
+	return err == nil
+}
+
+// RunFirstTimeSetup performs an interactive configuration when the config file does not exist.
+func RunFirstTimeSetup() {
+	reader := bufio.NewReader(os.Stdin)
+	clearTerminal()
+	fmt.Println(ColorGreen + "🌿 Welcome to the Grove Developer Interface (GDI)! It looks like this is the first time you're using it." + ColorReset)
+
+	fmt.Print(ColorBlue + "❓ Would you like to configure it now? (y/n): " + ColorReset)
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	clearTerminal()
+	if answer != "y" {
+		fmt.Println(ColorYellow + "👋 Exiting GDI configuration. You can configure later using 'gdi config'." + ColorReset)
+		os.Exit(0)
+	}
+
+	// Prepare configuration data
+	configData := make(map[string]interface{})
+
+	// Optionally configure git_config
+	fmt.Print(ColorGreen + "❓ Would you like to configure git configuration?" + ColorReset + "\nThis is only necessary for private repositories. It must be a valid PAT with at least `write:repo` scope." + ColorBlue + "\nYou may edit this choice later using 'gdi config'." + ColorReset + "\n(y/n): ")
+	answer, _ = reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	clearTerminal()
+	if answer == "y" {
+		token := readHiddenInput(ColorBlue + "📝 Enter your valid GitHub Personal Access Token (input hidden): " + ColorReset)
+		clearTerminal()
+		configData["git_config"] = map[string]interface{}{
+			"personal_access_token": token,
+		}
+	}
+
+	loadSchema()
+	llmConfig := make(map[string]interface{})
+	allowedProviders := getEnumOptionsForPath("llm_config.default_llm_provider")
+	if len(allowedProviders) == 0 {
+		log.Fatalf(ColorRed + "No allowed LLM providers found in schema." + ColorReset)
+	}
+
+	fmt.Println(ColorGreen + "🛠️ Configure LLM: You must set a default LLM provider.\n" + ColorReset + "(You may override this provider per-request with the `-p|--provider` flag.)\n" + ColorBlue + "Choose one of the following options:" + ColorReset)
+	for i, p := range allowedProviders {
+		fmt.Printf("%d. "+ColorPurple+"%s"+ColorReset+"\n", i+1, p)
+	}
+	var defaultProvider string
+	for {
+		fmt.Print(ColorBlue + "📝 Enter choice (number): " + ColorReset)
+		choiceStr, _ := reader.ReadString('\n')
+		choiceStr = strings.TrimSpace(choiceStr)
+		clearTerminal()
+		choice, err := strconv.Atoi(choiceStr)
+		if err != nil || choice < 1 || choice > len(allowedProviders) {
+			fmt.Println(ColorRed + "Invalid choice. Please try again." + ColorReset)
+			continue
+		}
+		defaultProvider = allowedProviders[choice-1]
+		break
+	}
+	llmConfig["default_llm_provider"] = defaultProvider
+
+	// Configure default provider details
+	llmProviders := make(map[string]interface{})
+	fmt.Printf(ColorGreen+"🛠️ Configuring provider '%s'.\n"+ColorReset, defaultProvider)
+	providerDetails := promptForProviderConfiguration(reader, defaultProvider)
+	llmProviders[defaultProvider] = providerDetails
+
+	// Ask about additional providers
+	fmt.Print(ColorGreen + "❓ Would you like to configure any other LLM providers? (y/n): " + ColorReset)
+	answer, _ = reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	clearTerminal()
+	if answer == "y" {
+		for {
+			// List remaining providers
+			remaining := []string{}
+			for _, p := range allowedProviders {
+				if _, exists := llmProviders[p]; !exists {
+					remaining = append(remaining, p)
+				}
+			}
+			if len(remaining) == 0 {
+				fmt.Println(ColorYellow + "✅ All LLM providers have been configured. You can edit the configuration later using 'gdi config'." + ColorReset)
+				break
+			}
+			fmt.Println(ColorGreen + "🛠️ Select an LLM provider to configure from the following:" + ColorReset)
+			for i, p := range remaining {
+				fmt.Printf("%d. "+ColorPurple+"%s"+ColorReset+"\n", i+1, p)
+			}
+			fmt.Print(ColorBlue + "📝 Enter choice (number): " + ColorReset)
+			choiceStr, _ := reader.ReadString('\n')
+			choiceStr = strings.TrimSpace(choiceStr)
+			clearTerminal()
+			choice, err := strconv.Atoi(choiceStr)
+			if err != nil || choice < 1 || choice > len(remaining) {
+				fmt.Println(ColorRed + "Invalid choice. Please try again." + ColorReset)
+				continue
+			}
+			selectedProvider := remaining[choice-1]
+			fmt.Printf(ColorGreen+"🛠️ Configuring LLM provider '%s'.\n"+ColorReset, selectedProvider)
+			details := promptForProviderConfiguration(reader, selectedProvider)
+			llmProviders[selectedProvider] = details
+
+			fmt.Print(ColorGreen + "❓ Would you like to configure another LLM provider? (y/n): " + ColorReset)
+			cont, _ := reader.ReadString('\n')
+			cont = strings.TrimSpace(strings.ToLower(cont))
+			clearTerminal()
+			if cont != "y" {
+				break
+			}
+		}
+	}
+	llmConfig["llm_providers"] = llmProviders
+	configData["llm_config"] = llmConfig
+
+	// Save configuration to YAML file
+	yamlData, err := yaml.Marshal(configData)
+	if err != nil {
+		log.Fatalf(ColorRed+"Failed to marshal configuration to YAML: %v"+ColorReset, err)
+	}
+	err = os.WriteFile(configPkg.ConfigFilePath, yamlData, 0644)
+	if err != nil {
+		log.Fatalf(ColorRed+"Failed to write configuration file: %v"+ColorReset, err)
+	}
+
+	fmt.Println(ColorGreen + "🌿 Configuration completed and saved. You may edit the configuration later by running 'gdi config'." + ColorReset)
+}
+
+// promptForProviderConfiguration prompts the user for provider details (api_key and client_model) and returns them as a map.
+func promptForProviderConfiguration(reader *bufio.Reader, provider string) map[string]interface{} {
+	details := make(map[string]interface{})
+	apiKey := readHiddenInput(ColorGreen + "🔑 Enter API key for " + provider + " (input hidden): " + ColorReset)
+	clearTerminal()
+	details["api_key"] = apiKey
+
+	allowedModels := getEnumOptionsForPath("llm_config.llm_providers." + provider + ".client_model")
+	if len(allowedModels) > 0 {
+		fmt.Printf(ColorGreen+"🤖 Select a default client model for %s:\n"+ColorReset+"(You may override this model per-request with the `-m|--model` flag.)\n", provider)
+		for i, model := range allowedModels {
+			fmt.Printf("%d. "+ColorPurple+"%s"+ColorReset+"\n", i+1, model)
+		}
+		var clientModel string
+		for {
+			fmt.Print(ColorBlue + "📝 Enter choice (number): " + ColorReset)
+			choiceStr, _ := reader.ReadString('\n')
+			choiceStr = strings.TrimSpace(choiceStr)
+			clearTerminal()
+			choice, err := strconv.Atoi(choiceStr)
+			if err != nil || choice < 1 || choice > len(allowedModels) {
+				fmt.Println(ColorRed + "Invalid choice. Please try again." + ColorReset)
+				continue
+			}
+			clientModel = allowedModels[choice-1]
+			break
+		}
+		details["client_model"] = clientModel
+	} else {
+		fmt.Printf(ColorGreen+"🤖 Enter client model for %s: "+ColorReset, provider)
+		clientModel, _ := reader.ReadString('\n')
+		clientModel = strings.TrimSpace(clientModel)
+		clearTerminal()
+		details["client_model"] = clientModel
+	}
+	return details
+}
+
+// Add helper function to read hidden input using golang.org/x/term
+func readHiddenInput(prompt string) string {
+	fmt.Print(prompt)
+	byteInput, err := term.ReadPassword(int(os.Stdin.Fd()))
+	if err != nil {
+		log.Fatalf(ColorRed+"Failed to read hidden input: %v"+ColorReset, err)
+	}
+	fmt.Println("")
+	return strings.TrimSpace(string(byteInput))
+}

--- a/cmd/config/init.go
+++ b/cmd/config/init.go
@@ -22,7 +22,7 @@ func ConfigExists() bool {
 }
 
 // RunFirstTimeSetup performs an interactive configuration when the config file does not exist.
-func RunFirstTimeSetup() {
+func RunFirstTimeSetup() error {
 	reader := bufio.NewReader(os.Stdin)
 	clearTerminal()
 	fmt.Println(ColorGreen + "🌿 Welcome to the Grove Developer Interface (GDI)! It looks like this is the first time you're using it." + ColorReset)
@@ -52,7 +52,9 @@ func RunFirstTimeSetup() {
 		}
 	}
 
-	loadSchema()
+	// Load embedded schema. schemaMap var is already defined in root.go
+	configPkg.LoadSchema(&schemaMap)
+
 	llmConfig := make(map[string]interface{})
 	allowedProviders := getEnumOptionsForPath("llm_config.default_llm_provider")
 	if len(allowedProviders) == 0 {
@@ -144,12 +146,14 @@ func RunFirstTimeSetup() {
 	}
 
 	fmt.Println(ColorGreen + "🌿 Configuration completed and saved. You may edit the configuration later by running 'gdi config'." + ColorReset)
+
+	return nil
 }
 
 // promptForProviderConfiguration prompts the user for provider details (api_key and client_model) and returns them as a map.
 func promptForProviderConfiguration(reader *bufio.Reader, provider string) map[string]interface{} {
 	details := make(map[string]interface{})
-	apiKey := readHiddenInput(ColorGreen + "🔑 Enter API key for " + provider + " (input hidden): " + ColorReset)
+	apiKey := readHiddenInput(ColorBlue + "🔑 Enter API key for " + provider + " (input hidden): " + ColorReset)
 	clearTerminal()
 	details["api_key"] = apiKey
 

--- a/cmd/config/root.go
+++ b/cmd/config/root.go
@@ -41,6 +41,8 @@ import (
 	"strconv"
 	"strings"
 
+	_ "embed"
+
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
@@ -135,8 +137,8 @@ func interactiveEditConfigV3() {
 		log.Fatalf(ColorRed+"Failed to unmarshal YAML: %v"+ColorReset, err)
 	}
 
-	// Load the configuration schema from the repository root.
-	loadSchema()
+	// Load the configuration schema from the embedded schema.
+	config.LoadSchema(&schemaMap)
 
 	// Interactive editing loop.
 	for {
@@ -165,19 +167,6 @@ func clearTerminal() {
 	cmd := exec.Command("clear")
 	cmd.Stdout = os.Stdout
 	cmd.Run()
-}
-
-// loadSchema reads the configuration schema from ./config/config.schema.yaml into schemaMap.
-func loadSchema() {
-	schemaFile := "./config/config.schema.yaml"
-	data, err := os.ReadFile(schemaFile)
-	if err != nil {
-		log.Fatalf(ColorRed+"Failed to read schema file at %s: %v"+ColorReset, schemaFile, err)
-	}
-	err = yaml.Unmarshal(data, &schemaMap)
-	if err != nil {
-		log.Fatalf(ColorRed+"Failed to unmarshal schema YAML: %v"+ColorReset, err)
-	}
 }
 
 // getEnumOptionsForPath traverses the schema using a dot-delimited field path

--- a/cmd/git/createpr.go
+++ b/cmd/git/createpr.go
@@ -51,7 +51,7 @@ var llmModelOverride string
 
 func init() {
 	// Initialize Git-related flags.
-	createprCmd.Flags().StringVarP(&prTitle, "pr-title", "t", "", "PR title to open the PR with. Should be descriptive and contain relevant tags. [REQUIRED]")
+	createprCmd.Flags().StringVarP(&prTitle, "pr-title", "t", "", "PR title to open the PR with. Should be descriptive and contain relevant tags. Will open a draft PR if the string contains [DRAFT] or [WIP]. [REQUIRED]")
 	createprCmd.Flags().StringVarP(&targetBranch, "target-branch", "b", "main", "Target branch to open the PR on. [OPTIONAL, defaults to 'main']")
 	createprCmd.Flags().IntVarP(&issue, "issue", "i", 0, "Issue number to assign to the PR. [OPTIONAL]")
 	createprCmd.Flags().BoolVarP(&dummy, "dummy", "d", false, "Dummy mode. If true, the command will not create a PR but will only print the PR description and copy to clipboard [OPTIONAL, defaults to 'false']")
@@ -203,7 +203,8 @@ func buildPrompt(prTitle, diff string) string {
 // isDraft checks if the PR title contains "DRAFT" (case-insensitive).
 // If it does, the PR will be created as a draft.
 func isDraft(prTitle string) bool {
-	return strings.Contains(strings.ToUpper(prTitle), "DRAFT")
+	return strings.Contains(strings.ToUpper(prTitle), "DRAFT") ||
+		strings.Contains(strings.ToUpper(prTitle), "WIP")
 }
 
 // buildPRDescription builds the final PR description from the LLM response.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,9 +18,7 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -29,9 +27,12 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:     "gdi",
-	Short:   "Grove Developer Interface - streamline your development workflows",
-	Long:    "", //Assigned in generateLongDescription()
+	Use:   "gdi",
+	Short: "Grove Developer Interface - streamline your development workflows",
+	Long: `Grove Developer Interface (GDI) is a comprehensive CLI tool designed for internal
+	development at Grove. It provides users with a unified approach to manage configuration
+	settings, execute Git operations, and interact with integrated LLM providers for tasks
+	such as automated pull request generation.`,
 	Version: "0.0.1",
 }
 
@@ -39,7 +40,6 @@ func init() {
 	rootCmd.Flags().BoolP("toggle", "t", false, "Toggle verbose mode or other options")
 	rootCmd.AddCommand(git.GitCmd)
 	rootCmd.AddCommand(config.ConfigCmd)
-	rootCmd.Long = generateLongDescription()
 
 	if !config.ConfigExists() {
 		config.RunFirstTimeSetup()
@@ -50,29 +50,5 @@ func init() {
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
-	}
-}
-
-// generateLongDescription generates the long description for the root command.
-func generateLongDescription() string {
-	var sb strings.Builder
-	sb.WriteString(`Grove Developer Interface (GDI) is a comprehensive CLI tool designed for internal
-	development at Grove. It provides users with a unified approach to manage configuration
-	settings, execute Git operations, and interact with integrated LLM providers for tasks
-	such as automated pull request generation.
-
-	Available Commands:
-	`)
-	appendCommands(&sb, rootCmd, "")
-	return sb.String()
-}
-
-// appendCommands appends the commands to the long description.
-func appendCommands(sb *strings.Builder, cmd *cobra.Command, prefix string) {
-	for _, c := range cmd.Commands() {
-		if !c.Hidden {
-			sb.WriteString(fmt.Sprintf("%s  %-10s %s\n", prefix, c.Name(), c.Short))
-			appendCommands(sb, c, prefix+"  ")
-		}
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,9 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -27,13 +29,22 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "gdi",
-	Short: "Grove Developer Interface - streamline your development workflows",
-	Long: `Grove Developer Interface (GDI) is a comprehensive CLI tool designed for internal
-development at Grove. It provides users with a unified approach to manage configuration
-settings, execute Git operations, and interact with integrated LLM providers for tasks
-such as automated pull request generation.`,
+	Use:     "gdi",
+	Short:   "Grove Developer Interface - streamline your development workflows",
+	Long:    "", //Assigned in generateLongDescription()
 	Version: "0.0.1",
+}
+
+func init() {
+	rootCmd.Flags().BoolP("toggle", "t", false, "Toggle verbose mode or other options")
+	rootCmd.AddCommand(git.GitCmd)
+	rootCmd.AddCommand(config.ConfigCmd)
+	rootCmd.Long = generateLongDescription()
+
+	if !config.ConfigExists() {
+		config.RunFirstTimeSetup()
+		return
+	}
 }
 
 func Execute() {
@@ -43,8 +54,26 @@ func Execute() {
 	}
 }
 
-func init() {
-	rootCmd.Flags().BoolP("toggle", "t", false, "Toggle verbose mode or other options")
-	rootCmd.AddCommand(git.GitCmd)
-	rootCmd.AddCommand(config.ConfigCmd)
+// generateLongDescription generates the long description for the root command.
+func generateLongDescription() string {
+	var sb strings.Builder
+	sb.WriteString(`Grove Developer Interface (GDI) is a comprehensive CLI tool designed for internal
+	development at Grove. It provides users with a unified approach to manage configuration
+	settings, execute Git operations, and interact with integrated LLM providers for tasks
+	such as automated pull request generation.
+
+	Available Commands:
+	`)
+	appendCommands(&sb, rootCmd, "")
+	return sb.String()
+}
+
+// appendCommands appends the commands to the long description.
+func appendCommands(sb *strings.Builder, cmd *cobra.Command, prefix string) {
+	for _, c := range cmd.Commands() {
+		if !c.Hidden {
+			sb.WriteString(fmt.Sprintf("%s  %-10s %s\n", prefix, c.Name(), c.Short))
+			appendCommands(sb, c, prefix+"  ")
+		}
+	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,8 +48,7 @@ func init() {
 }
 
 func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
+	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,15 +4,15 @@
 //
 // Overview:
 //
-//	The 🌿 Grove Developer Interface (GDI) 🌿 is a command-line tool designed to streamline
-//	internal developer workflows at Grove. GDI helps developers quickly perform routine
-//	tasks and maintain consistency across projects.
+// The 🌿 Grove Developer Interface (GDI) 🌿 is a command-line tool designed to streamline
+// internal developer workflows at Grove. GDI is intended to help developers quickly perform
+// routine operations and maintain consistency across projects.
 //
 // DEV_NOTE:
 //
-//	This repo is also intended to be a living project and should be updated to incorporate
-//	any of your own scripts, hacks, time-saving features that you use in your local
-//	workflows and that you think could benefit the entire team.
+// This repo is also intended to be a living project and should be updated to incorporate
+// any of our own scripts, hacks, time-saving features, etc. that we use in our local
+// development workflows and that could benefit the entire team to share in this CLI
 //
 // ---------------------------------------------------------------------------
 package cmd

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"os"
 
+	_ "embed"
+
 	"gopkg.in/yaml.v3"
 
 	"github.com/buildwithgrove/gdi/config/git"
@@ -42,4 +44,19 @@ func LoadConfig() (*Config, error) {
 	}
 
 	return &config, nil
+}
+
+// Embed the schema file in the binary for use in the config command.
+// This is to allow the schema file to be loaded in the config command,
+// regardless of where the binary is run from.
+//
+//go:embed config.schema.yaml
+var schemaYaml []byte
+
+// LoadSchema loads the embedded schema from the config.schema.yaml file.
+func LoadSchema(schema *map[string]interface{}) error {
+	if err := yaml.Unmarshal(schemaYaml, &schema); err != nil {
+		return err
+	}
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/sashabaranov/go-openai v1.37.0
 	github.com/spf13/cobra v1.9.1
 	golang.design/x/clipboard v0.7.0
+	golang.org/x/term v0.28.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 


### PR DESCRIPTION
## 🌿 Summary

Implement an initialization script to streamline GDI configuration for first-time users.

### 🌱 Primary Changes:
- Added `init.go` for first-time setup of GDI configuration.
- Implemented `createpr.go` command for automated GitHub PR creation.
- Introduced LLM provider configuration in `config/llm`.

### 🍃 Secondary changes:
- Updated `README.md` to include new usage instructions.
- Refactored `cmd/root.go` for better modularity with new commands.


## 🛠️ Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## 🤯 Sanity Checklist

- [ ] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [ ] For docs, I have run 'make docusaurus_start'
- [ ] For code, I have run 'make test_all'
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
