### PR TITLE
[ENHANCEMENT] Add -u flag to update existing PR description rather than creating a new one.

### DIFF
--- a/cmd/git/createpr.go
+++ b/cmd/git/createpr.go
@@ -118,8 +118,32 @@ Flags:
 			log.Fatalf("failed to get LLM provider: %v", err)
 		}
 
-		logger.Info().
-			Str("dummy", fmt.Sprintf("%t", dummy)).Msg("Initialization successful. Running Create PR command.")
+		// Retrieve the current branch name.
+		currentBranchName, err := gitProvider.GetCurrentBranchName()
+		if err != nil {
+			log.Fatalf("failed to get current branch name: %v", err)
+		}
+
+		logger = logger.With(
+			"dummy", dummy,
+			"current_branch", currentBranchName,
+			"target_branch", targetBranch,
+			"type", "create",
+		)
+
+		// If updating an existing PR, get the target branch.
+		if updatePRNumber != 0 {
+			targetBranch, err = gitProvider.GetPRTargetBranch(context.Background(), updatePRNumber)
+			if err != nil {
+				log.Fatalf("failed to get PR target branch: %v", err)
+			}
+			logger = logger.With(
+				"target_branch", targetBranch,
+				"type", "update",
+			)
+		}
+
+		logger.Info().Msg("Initialization successful. Running command...")
 
 		// Generate a diff from Git against the target branch.
 		diff, err := gitProvider.GenerateDiff(context.Background(), targetBranch)

--- a/cmd/git/createpr.go
+++ b/cmd/git/createpr.go
@@ -119,14 +119,14 @@ Flags:
 		}
 
 		// Retrieve the current branch name.
-		currentBranchName, err := gitProvider.GetCurrentBranchName()
+		currentBranch, err := gitProvider.GetCurrentBranchName()
 		if err != nil {
 			log.Fatalf("failed to get current branch name: %v", err)
 		}
 
 		logger = logger.With(
 			"dummy", dummy,
-			"current_branch", currentBranchName,
+			"current_branch", currentBranch,
 			"target_branch", targetBranch,
 			"type", "create",
 		)
@@ -208,10 +208,11 @@ Flags:
 
 		// Construct the pull request configuration.
 		pullRequestConfig := git.PullRequestConfig{
-			TargetBranch: targetBranch,
-			Title:        prTitle,
-			Body:         prDescription,
-			Draft:        isDraft(prTitle),
+			CurrentBranch: currentBranch,
+			TargetBranch:  targetBranch,
+			Title:         prTitle,
+			Body:          prDescription,
+			Draft:         isDraft(prTitle),
 		}
 		// If an issue number is provided, add it to the configuration.
 		if issue != 0 {

--- a/cmd/git/createpr.go
+++ b/cmd/git/createpr.go
@@ -44,6 +44,7 @@ var prTitle string
 var issue int
 var targetBranch string
 var dummy bool
+var updatePRNumber int
 
 // LLM config flags
 var llmProviderOverride string
@@ -55,6 +56,7 @@ func init() {
 	createprCmd.Flags().IntVarP(&issue, "issue", "i", 0, "Issue number to assign to the PR. [ONE OF THE FOLLOWING FLAGS MUST BE PROVIDED: -t or -i]")
 	createprCmd.Flags().StringVarP(&targetBranch, "target-branch", "b", "main", "Target branch to open the PR on. [OPTIONAL, defaults to 'main']")
 	createprCmd.Flags().BoolVarP(&dummy, "dummy", "d", false, "Dummy mode. If true, the command will not create a PR but will only print the PR description and copy to clipboard [OPTIONAL, defaults to 'false']")
+	createprCmd.Flags().IntVarP(&updatePRNumber, "update", "u", 0, "Update an existing PR with the given pull request number. [OPTIONAL]")
 	// Initialize LLM-related flags.
 	createprCmd.Flags().StringVarP(&llmProviderOverride, "provider-override", "p", "", "LLM provider override. If set the default provider in the config will be overridden. [OPTIONAL]")
 	createprCmd.Flags().StringVarP(&llmModelOverride, "model-override", "m", "", "LLM model override. If set the default model in the config will be overridden. [OPTIONAL]")
@@ -77,6 +79,7 @@ Flags:
   --issue (-i)      : Issue number to assign to the PR. (Exactly one of the following flags must be provided: -t or -i)
   --target-branch (-b): Target branch (default "main").
   --dummy (-d)      : If set, the PR is not created; instead, the description is printed and copied.
+  --update (-u)     : Update an existing PR with the given pull request number. Cannot be used with --issue.
   --provider-override (-p): Optional LLM provider override.
   --model-override (-m)   : Optional LLM model override.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -90,6 +93,9 @@ Flags:
 		}
 		if prTitle != "" && issue != 0 {
 			log.Fatalf("PR title and issue number cannot both be provided")
+		}
+		if updatePRNumber != 0 && issue != 0 {
+			log.Fatalf("Update PR number and issue number cannot both be provided")
 		}
 
 		// Load configuration from the config YAML file.
@@ -163,6 +169,16 @@ Flags:
 			fmt.Printf("PR Description:\n\n%s\n", prDescription)
 			clipboard.Write(clipboard.FmtText, []byte(prDescription))
 			logger.Info().Msg("PR description copied to clipboard. PR not created.")
+			return
+		}
+
+		// If an update PR number is provided, update the pull request.
+		if updatePRNumber != 0 {
+			pullRequest, err := gitProvider.UpdatePullRequestBody(context.Background(), updatePRNumber, prTitle, prDescription)
+			if err != nil {
+				log.Fatalf("failed to update pull request: %v", err)
+			}
+			fmt.Printf("✅ Pull request # %d updated Successfully!\n🌿 Pull Request URL: %s\n", *pullRequest.Number, *pullRequest.HTMLURL)
 			return
 		}
 

--- a/git/git.go
+++ b/git/git.go
@@ -81,16 +81,20 @@ func NewGitProvider(logger polylog.Logger, cfg gitCfg.Config) (*Provider, error)
 
 // PullRequestConfig holds configuration options for creating a pull request.
 type PullRequestConfig struct {
-	TargetBranch string // The target branch for the pull request.
-	Title        string // The title of the pull request.
-	Body         string // The body/description of the pull request.
-	Draft        bool   // Indicates whether the PR should be created as a draft.
-	Issue        int    // Optional issue number to associate with the PR.
+	CurrentBranch string // The current branch for the pull request.
+	TargetBranch  string // The target branch for the pull request.
+	Title         string // The title of the pull request.
+	Body          string // The body/description of the pull request.
+	Draft         bool   // Indicates whether the PR should be created as a draft.
+	Issue         int    // Optional issue number to associate with the PR.
 }
 
 // IsValid checks if the pull request configuration is valid.
 // It ensures that TargetBranch, Title, and Body are not empty.
 func (cfg PullRequestConfig) IsValid() error {
+	if cfg.CurrentBranch == "" {
+		return fmt.Errorf("pull request config error: current branch is required")
+	}
 	if cfg.TargetBranch == "" {
 		return fmt.Errorf("pull request config error: target branch is required")
 	}
@@ -123,20 +127,15 @@ func (p *Provider) CreatePullRequest(ctx context.Context, cfg PullRequestConfig)
 		return nil, fmt.Errorf("failed to get repo name: %w", err)
 	}
 
-	// Retrieve the current branch name.
-	currentBranchName, err := p.getCurrentBranchName()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get current branch name: %w", err)
-	}
 	// Ensure the current branch is pushed to the remote repository.
-	err = p.PushBranchToRemote(currentBranchName)
+	err = p.PushBranchToRemote(cfg.CurrentBranch)
 	if err != nil {
 		return nil, fmt.Errorf("failed to push branch to remote: %w", err)
 	}
 
 	// Construct the new pull request payload.
 	newPR := &github.NewPullRequest{
-		Head:  github.Ptr(currentBranchName),
+		Head:  github.Ptr(cfg.CurrentBranch),
 		Base:  github.Ptr(cfg.TargetBranch),
 		Body:  github.Ptr(cfg.Body),
 		Draft: github.Ptr(cfg.Draft),
@@ -195,6 +194,26 @@ func (p *Provider) UpdatePullRequestBody(ctx context.Context, number int, title,
 	// Log the URL of the updated pull request.
 	p.logger.Info().Str("url", pr.GetHTMLURL()).Msg("updated pull request")
 	return pr, nil
+}
+
+// GetPRTargetBranch retrieves the target branch of a pull request.
+func (p *Provider) GetPRTargetBranch(ctx context.Context, number int) (string, error) {
+	repoName, err := p.getCurrentRepoName()
+	if err != nil {
+		return "", fmt.Errorf("failed to get repo name: %w", err)
+	}
+
+	pr, _, err := p.PullRequests.Get(ctx, repoOwner, repoName, number)
+	if err != nil {
+		return "", fmt.Errorf("failed to get pull request: %w", err)
+	}
+
+	ref := pr.GetBase().GetRef()
+	if ref == "" {
+		return "", fmt.Errorf("pull request target branch is empty")
+	}
+
+	return ref, nil
 }
 
 // PushBranchToRemote pushes the specified branch to the remote repository using the stored personal access token.
@@ -332,7 +351,7 @@ func (p *Provider) getCurrentRepoName() (string, error) {
 
 // getCurrentBranchName returns the name of the current branch in the repository.
 // It retrieves the HEAD reference and extracts the branch's short name.
-func (p *Provider) getCurrentBranchName() (string, error) {
+func (p *Provider) GetCurrentBranchName() (string, error) {
 	// Get the current directory.
 	dir, err := os.Getwd()
 	if err != nil {

--- a/git/git.go
+++ b/git/git.go
@@ -162,6 +162,41 @@ func (p *Provider) CreatePullRequest(ctx context.Context, cfg PullRequestConfig)
 	return pr, nil
 }
 
+// UpdatePullRequestBody updates the title and body of an existing pull request.
+func (p *Provider) UpdatePullRequestBody(ctx context.Context, number int, title, body string) (*github.PullRequest, error) {
+	if number == 0 {
+		return nil, fmt.Errorf("pull request number is required")
+	}
+	if title == "" {
+		return nil, fmt.Errorf("pull request title is required")
+	}
+	if body == "" {
+		return nil, fmt.Errorf("pull request body is required")
+	}
+
+	// Retrieve the current repository name.
+	repoName, err := p.getCurrentRepoName()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get repo name: %w", err)
+	}
+
+	// Create a pull request object with the new title and body.
+	pull := &github.PullRequest{
+		Title: github.Ptr(title),
+		Body:  github.Ptr(body),
+	}
+
+	// Call the Edit method to update the pull request.
+	pr, _, err := p.PullRequests.Edit(ctx, repoOwner, repoName, number, pull)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update pull request: %w", err)
+	}
+
+	// Log the URL of the updated pull request.
+	p.logger.Info().Str("url", pr.GetHTMLURL()).Msg("updated pull request")
+	return pr, nil
+}
+
 // PushBranchToRemote pushes the specified branch to the remote repository using the stored personal access token.
 // It constructs and executes the "git push" command.
 func (p *Provider) PushBranchToRemote(branchName string) error {


### PR DESCRIPTION
## 🌿 Summary

Add `-u` flag to update existing PR descriptions instead of creating new ones.

### 🌱 Primary Changes:
- Added `-u`/`--update` flag to update existing PR descriptions
- Implemented `UpdatePullRequestBody` method to handle PR updates via GitHub API
- Added `GetPRTargetBranch` method to fetch target branch for existing PRs

### 🍃 Secondary changes:
- Refactored branch handling to use `CurrentBranch` in config
- Improved logging with additional context (branch names, operation type)

## 🛠️ Type of change

Select one or more from the following:

- [x] New feature, functionality or library